### PR TITLE
Vaadin7 components from compatibility module are available (fixes htt…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,16 @@
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-themes</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-compatibility-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-compatibility-client</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
@@ -90,6 +100,7 @@
                     <!-- You are free to mark this as permanently ignored in Eclipse -->
                     <execution>
                         <configuration>
+                            <extraJvmArgs>-Xmx1024M</extraJvmArgs> <!-- Lower value can cause OutOfMemoryErrors for 8.0-SNAPSHOT -->
                             <!-- if you don't specify any modules, the plugin will find them -->
                         </configuration>
                         <goals>

--- a/src/main/java/MyAppWidgetset.gwt.xml
+++ b/src/main/java/MyAppWidgetset.gwt.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.5.1//EN" "http://google-web-toolkit.googlecode.com/svn/tags/2.5.1/distro-source/core/src/gwt-module.dtd">
+<module>
+    <inherits name="com.vaadin.DefaultWidgetSet"/>
+    
+    <!--
+    Any other modules, for example charts addon:
+    
+    -->
+
+    <inherits name="com.vaadin.v7.Vaadin7WidgetSet" />
+</module>

--- a/src/main/java/de/wetego/vaadin/DemoUI.java
+++ b/src/main/java/de/wetego/vaadin/DemoUI.java
@@ -5,15 +5,16 @@ import javax.servlet.annotation.WebServlet;
 import com.vaadin.annotations.PreserveOnRefresh;
 import com.vaadin.annotations.Theme;
 import com.vaadin.annotations.Title;
+import com.vaadin.annotations.Widgetset;
 import com.vaadin.annotations.VaadinServletConfiguration;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.spring.annotation.SpringUI;
 import com.vaadin.spring.server.SpringVaadinServlet;
 import com.vaadin.ui.Button;
-import com.vaadin.ui.Label;
 import com.vaadin.ui.TextField;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
+import com.vaadin.v7.ui.Label;
 
 
 /**
@@ -24,6 +25,7 @@ import com.vaadin.ui.VerticalLayout;
 @Title ( "Vaadin8 - Spring Boot Application" )
 @SpringUI
 @PreserveOnRefresh
+@Widgetset("MyAppWidgetset")
 public class DemoUI extends UI {
 
     @Override


### PR DESCRIPTION
Adding vaadin-compatibility-X modules 

Fixes: #1 

Solution based on my [vaadin forum thread](https://vaadin.com/forum#!/thread/15031831) compatible with beta1 and 8.0-SNAPSHOT.

Solution enables the use of addons + provides a workaround for an OutOfMemoryError occuring when compiling widgetset using 8.0-SNAPSHOT.

Probably it would be reasonable to include the solution in a separate branch, for those wanting a pure vaadin8 solution